### PR TITLE
Fix telescope live-grep-args mappings

### DIFF
--- a/lua/kobra/plugins/editor.lua
+++ b/lua/kobra/plugins/editor.lua
@@ -167,7 +167,7 @@ M[#M + 1] = {
 				live_grep_args = {
 					mappings = {
 						i = {
-							["<c-'>"] = require("telescope-live-grep-args.actions").quote_prompt(),
+							["<c-g>"] = require("telescope-live-grep-args.actions").quote_prompt(),
 							["<c-i>"] = require("telescope-live-grep-args.actions").quote_prompt({
 								postfix = " --iglob ",
 							}),

--- a/lua/kobra/plugins/editor.lua
+++ b/lua/kobra/plugins/editor.lua
@@ -167,7 +167,7 @@ M[#M + 1] = {
 				live_grep_args = {
 					mappings = {
 						i = {
-							["<c-g"] = require("telescope-live-grep-args.actions").quote_prompt(),
+							["<c-'>"] = require("telescope-live-grep-args.actions").quote_prompt(),
 							["<c-i>"] = require("telescope-live-grep-args.actions").quote_prompt({
 								postfix = " --iglob ",
 							}),

--- a/lua/kobra/plugins/editor.lua
+++ b/lua/kobra/plugins/editor.lua
@@ -167,14 +167,10 @@ M[#M + 1] = {
 				live_grep_args = {
 					mappings = {
 						i = {
-							["<c-p"] = function()
-								return require("telescope-live-grep-args.actions").quote_promt()
-							end,
-							["<c-g>"] = function()
-								return require("telescope-live-grep-args.actions").quote_prompt({
-									postfix = " --iglob ",
-								})
-							end,
+							["<c-p"] = require("telescope-live-grep-args.actions").quote_promt(),
+							["<c-g>"] = require("telescope-live-grep-args.actions").quote_prompt({
+								postfix = " --iglob ",
+							}),
 						},
 					},
 				},

--- a/lua/kobra/plugins/editor.lua
+++ b/lua/kobra/plugins/editor.lua
@@ -167,8 +167,8 @@ M[#M + 1] = {
 				live_grep_args = {
 					mappings = {
 						i = {
-							["<c-p"] = require("telescope-live-grep-args.actions").quote_prompt(),
-							["<c-g>"] = require("telescope-live-grep-args.actions").quote_prompt({
+							["<c-'"] = require("telescope-live-grep-args.actions").quote_prompt(),
+							["<c-i>"] = require("telescope-live-grep-args.actions").quote_prompt({
 								postfix = " --iglob ",
 							}),
 						},

--- a/lua/kobra/plugins/editor.lua
+++ b/lua/kobra/plugins/editor.lua
@@ -167,7 +167,7 @@ M[#M + 1] = {
 				live_grep_args = {
 					mappings = {
 						i = {
-							["<c-'"] = require("telescope-live-grep-args.actions").quote_prompt(),
+							["<c-g"] = require("telescope-live-grep-args.actions").quote_prompt(),
 							["<c-i>"] = require("telescope-live-grep-args.actions").quote_prompt({
 								postfix = " --iglob ",
 							}),

--- a/lua/kobra/plugins/editor.lua
+++ b/lua/kobra/plugins/editor.lua
@@ -167,7 +167,7 @@ M[#M + 1] = {
 				live_grep_args = {
 					mappings = {
 						i = {
-							["<c-p"] = require("telescope-live-grep-args.actions").quote_promt(),
+							["<c-p"] = require("telescope-live-grep-args.actions").quote_prompt(),
 							["<c-g>"] = require("telescope-live-grep-args.actions").quote_prompt({
 								postfix = " --iglob ",
 							}),

--- a/lua/kobra/plugins/editor.lua
+++ b/lua/kobra/plugins/editor.lua
@@ -167,10 +167,10 @@ M[#M + 1] = {
 				live_grep_args = {
 					mappings = {
 						i = {
-							["<c-'"] = function()
+							["<c-p"] = function()
 								return require("telescope-live-grep-args.actions").quote_promt()
 							end,
-							["<c-i>"] = function()
+							["<c-g>"] = function()
 								return require("telescope-live-grep-args.actions").quote_prompt({
 									postfix = " --iglob ",
 								})


### PR DESCRIPTION
Fixed and added <c-i> and <c-g> mappings for telescope live_grep_args